### PR TITLE
Adjust ADO to work with dev.azure.com with HTTPS remotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the "open-in-browser" extension will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.3] - 2024-12-23
+
+### Changed
+
+- Fixed Azure DevOps with HTTPS remotes to open on the `dev.azure.com` host. Previous `visualstudio.com` subdomains no longer work in my testing. SSH remotes need to be re-tested.
+
 ## [0.0.2] - 2024-02-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,16 +33,11 @@ VSCode 1.85.0 or newer
 
 ## Release Notes
 
-### 0.0.2 (Latest)
-
-#### Added
-
-- An extension-wide setting for the web platform. This is a convenience to avoid configuring many per-repo settings for repos that would otherwise be unrecognized.
-- Notifications for common error modes such as editing files that are not managed in Git
+### [0.0.3] - 2024-12-23
 
 #### Changed
 
-- Web platform resolution based on the remote URL's domain is now case-insensitive.
+- Fixed Azure DevOps with HTTPS remotes to open on the `dev.azure.com` host. Previous `visualstudio.com` subdomains no longer work in my testing. SSH remotes need to be re-tested.
 
 See [CHANGELOG.md](https://raw.githubusercontent.com/andrei-m/vscode-open-in-browser/main/CHANGELOG.md) for release history and work-in-progress.
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -18,9 +18,11 @@ export class GitInfo {
 export type MaybeGitInfo = GitInfo | null;
 
 export class UrlParsed {
+    protocol: string
     resource: string
     pathname: string
     constructor(resource: string, pathname: string) {
+        this.protocol = "ssh"
         this.resource = resource;
         this.pathname = pathname;
     }

--- a/src/test/open.test.ts
+++ b/src/test/open.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import { gitUrlToWebUrl } from '../open';
 import { UrlParsed, UrlPlatform }  from '../git';
 import { Selection } from '../editor';
+import GitUrlParse from 'git-url-parse';
 
 suite('gitUrlToWebUrl', () => {
 	test('Github single line', () => {
@@ -46,11 +47,18 @@ suite('gitUrlToWebUrl', () => {
 		assert.strictEqual(webUrl, 'https://stash.example.org/projects/project/repos/repo/browse/src/open.ts?at=deadbeef#3-5');
 	});
 
-    test('Azure DevOps single line', () => {
+    test('Azure DevOps SSH single line', () => {
         const url = new UrlParsed('ssh.dev.azure.com', '/v3/sub/org/repo.git');
         const selection = new Selection('src/open.ts', 1, 1);
         const webUrl = gitUrlToWebUrl(url, UrlPlatform.AzureDevOps, 'deadbeef', selection);
 		assert.strictEqual(webUrl, 'https://sub.visualstudio.com/org/_git/repo?path=/src/open.ts&version=GCdeadbeef&line=1&lineEnd=2&lineStartColumn=1&_a=contents');
+	});
+
+    test('Azure DevOps HTTPS single line', () => {
+        const url = GitUrlParse('https://user@dev.azure.com/some/org_name/_git/repo');
+        const selection = new Selection('src/open.ts', 1, 1);
+        const webUrl = gitUrlToWebUrl(url, UrlPlatform.AzureDevOps, 'deadbeef', selection);
+		assert.strictEqual(webUrl, 'https://dev.azure.com/some/org_name/_git/repo?path=/src/open.ts&version=GCdeadbeef&line=1&lineEnd=2&lineStartColumn=1&_a=contents');
 	});
 
     test('Azure DevOps path structure has fewer than 4 elements', () => {


### PR DESCRIPTION
Previous dev.visualstudio.com no longer resolves, which may be a change in ADO. This addresses the bug for ADO HTTPS remotes. SSH remotes need to be retested.